### PR TITLE
Bump debian, python and poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-slim-buster@sha256:fcfbcb15bc6bd589a7c4ce0000fd02b88ad3fc4a8360c272787944f69e2daf59 as python-base
+FROM python:3.10.4-slim-bullseye@sha256:e735a28fffb9f39bf4d8d50c364707a8e5274fe46e9b5a2974037098a0e0bdba as python-base
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED 1
 ENV PIP_NO_CACHE_DIR off
 ENV PIP_DEFAULT_TIMEOUT 100
 
-ENV POETRY_VERSION 1.1.7
+ENV POETRY_VERSION 1.1.13
 ENV POETRY_HOME /opt/poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT true
 ENV POETRY_NO_INTERACTION 1
@@ -22,7 +22,7 @@ FROM python-base
 
 RUN set -eux && \
     apt-get update && apt-get -y upgrade && \
-    apt-get install --yes --no-install-recommends curl=7.64.0-4+deb10u2 libpq-dev=11.16-0+deb10u1 && \
+    apt-get install --yes --no-install-recommends curl=7.74.0-1.3+deb11u1 libpq-dev=13.7-0+deb11u1 && \
     pip install --upgrade --no-cache-dir pip && \
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && \
     groupadd -r fakedata && \

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # fakedata-backend-base
 
-Randomicu base image from [python:3.9.6-slim-buster](https://hub.docker.com/layers/python/library/python/3.9.6-slim-buster/images/sha256-fcfbcb15bc6bd589a7c4ce0000fd02b88ad3fc4a8360c272787944f69e2daf59?context=explore) for fakedata-backend with pre-installed poetry and libpq-dev.
+Randomicu base image from [python:3.10.4-slim-bullseye](https://hub.docker.com/layers/python/library/python/3.10.4-slim-bullseye/images/sha256-e735a28fffb9f39bf4d8d50c364707a8e5274fe46e9b5a2974037098a0e0bdba?context=explore) for fakedata-backend with pre-installed poetry and libpq-dev.
 
 Debian package version search: https://packages.debian.org/index
 
 ## Environment
 
 OS libraries:
-1. `curl=7.64.0-4+deb10u2`
-2. `libpq-dev=11.16-0+deb10u`
+1. `curl=7.74.0-1.3+deb11u1`
+2. `libpq-dev=13.7-0+deb11u1`
 
 poetry environment variables:
 
-1. `POETRY_VERSION 1.1.7`
+1. `POETRY_VERSION 1.1.13`
 2. `POETRY_HOME /opt/poetry`
 3. `POETRY_VIRTUALENVS_IN_PROJECT true`
 4. `POETRY_NO_INTERACTION 1`


### PR DESCRIPTION
Bumps:
1. Debian to 11
2. Python to 3.10.4
3. Poetry to 1.1.13
4. curl=7.74.0-1.3+deb11u1
5. libpq-dev=13.7-0+deb11u1

Closes #22 Closes #23